### PR TITLE
implement tunnel checking and auto cleanup to address issue with stale tunnels

### DIFF
--- a/sirtunnel.py
+++ b/sirtunnel.py
@@ -3,7 +3,26 @@
 import sys
 import json
 import time
-from urllib import request
+from urllib import request, error
+
+
+def check_tunnel_health(tunnel_id):
+    check_url = 'http://127.0.0.1:2019/id/' + tunnel_id
+    try:
+        request.urlopen(check_url)
+    except error.HTTPError as e:
+        if e.code == 404:  # Not Found
+            return False
+    except error.URLError:
+        return False
+    return True
+
+
+def delete_tunnel(tunnel_id):
+    print("Cleaning up tunnel")
+    delete_url = 'http://127.0.0.1:2019/id/' + tunnel_id
+    req = request.Request(method='DELETE', url=delete_url)
+    request.urlopen(req)
 
 
 if __name__ == '__main__':
@@ -30,18 +49,18 @@ if __name__ == '__main__':
         'Content-Type': 'application/json'
     }
     create_url = 'http://127.0.0.1:2019/config/apps/http/servers/sirtunnel/routes'
-    req = request.Request(method='POST', url=create_url, headers=headers)
-    request.urlopen(req, body)
+    req = request.Request(method='POST', url=create_url, headers=headers, data=body)
+    request.urlopen(req)
 
     print("Tunnel created successfully")
 
     while True:
         try:
+            if not check_tunnel_health(tunnel_id):
+                print("Tunnel disconnected unexpectedly")
+                delete_tunnel(tunnel_id)
+                break
             time.sleep(1)
         except KeyboardInterrupt:
-
-            print("Cleaning up tunnel")
-            delete_url = 'http://127.0.0.1:2019/id/' + tunnel_id
-            req = request.Request(method='DELETE', url=delete_url)
-            request.urlopen(req)
+            delete_tunnel(tunnel_id)
             break


### PR DESCRIPTION
If you have an active tunnel and your laptop goes to sleep or whatever the server end does not properly handle the connection, when you reestablish the connection it will fail because the orphaned tunnel is still active. This pull request implements tunnel checking and auto cleanup. 